### PR TITLE
fix: replace iframe with webview for native fallback

### DIFF
--- a/frontend/components/MapView.tsx
+++ b/frontend/components/MapView.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Platform, View, Text, StyleSheet } from 'react-native';
+import { WebView } from 'react-native-webview';
 
 interface MapViewProps {
   style?: any;
@@ -54,15 +55,24 @@ const WebMapView: React.FC<MapViewProps> = ({ style, initialRegion, origin, dest
     mapsUrl = `https://www.google.com/maps/embed/v1/view?key=${process.env.EXPO_PUBLIC_GOOGLE_MAPS_API_KEY}&center=${initialRegion.latitude},${initialRegion.longitude}&zoom=15`;
   }
 
+  if (Platform.OS === 'web') {
+    return (
+      <View style={[styles.webMapContainer, style]}>
+        <iframe
+          src={mapsUrl}
+          style={styles.webMap}
+          allowFullScreen
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+        />
+        {children}
+      </View>
+    );
+  }
+
   return (
     <View style={[styles.webMapContainer, style]}>
-      <iframe
-        src={mapsUrl}
-        style={styles.webMap}
-        allowFullScreen
-        loading="lazy"
-        referrerPolicy="no-referrer-when-downgrade"
-      />
+      <WebView source={{ uri: mapsUrl }} style={styles.webMap} />
       {children}
     </View>
   );


### PR DESCRIPTION
## Summary
- avoid rendering iframe on native by using WebView fallback for maps

## Testing
- `yarn lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3a2919a0483288aa022ebe793c64f