### PR TITLE
fix: ensure service health checks have curl

### DIFF
--- a/api-v2/services/common/auth-service/Dockerfile
+++ b/api-v2/services/common/auth-service/Dockerfile
@@ -1,7 +1,17 @@
 FROM python:3.11-slim
+
 WORKDIR /app
+
+# Install curl for container health checks
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
 COPY . .
+
 EXPOSE 8014
+
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8014", "--reload"]

--- a/api-v2/services/common/provider-service/Dockerfile
+++ b/api-v2/services/common/provider-service/Dockerfile
@@ -1,7 +1,17 @@
 FROM python:3.11-slim
+
 WORKDIR /app
+
+# Install curl for container health checks
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
 COPY . .
+
 EXPOSE 8011
+
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8011", "--reload"]

--- a/api-v2/services/common/request-service/Dockerfile
+++ b/api-v2/services/common/request-service/Dockerfile
@@ -1,7 +1,17 @@
 FROM python:3.11-slim
+
 WORKDIR /app
+
+# Install curl for container health checks
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
 COPY . .
+
 EXPOSE 8012
+
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8012", "--reload"]


### PR DESCRIPTION
## Summary
- install curl in provider-service Docker image for health checks
- install curl in request-service Docker image for health checks
- install curl in auth-service Docker image for health checks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c813573628832890a4d6b761569bc8