### PR TITLE
Fix provider list rendering error

### DIFF
--- a/frontend/app/client/index.tsx
+++ b/frontend/app/client/index.tsx
@@ -646,7 +646,10 @@ export default function ClientScreen() {
     const distanceText = distanceKm != null ? `${distanceKm.toFixed(1)} km` : '—';
 
     return (
-      <Animated.View style={[styles.providerCard, { opacity: fadeAnim, transform: [{ scale: scaleAnim }] }]}>        <View style={styles.providerHeader}>
+      <Animated.View
+        style={[styles.providerCard, { opacity: fadeAnim, transform: [{ scale: scaleAnim }] }]}
+      >
+        <View style={styles.providerHeader}>
           <View style={styles.providerInfo}>
             <Text style={styles.providerName}>{item.name}</Text>
             <Text style={styles.providerCategory}>{item.category}</Text>


### PR DESCRIPTION
## Summary
- adjust the provider card JSX to place the nested view on a new line so React Native does not treat the whitespace as a bare text node
- prevent the client home screen from throwing the "Text strings must be rendered within a <Text> component" error when listing providers

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68ca0d6e61ac8328a2319fbccf5bdcd7