### PR TITLE
Fix API v2 module imports and align mobile config defaults

### DIFF
--- a/api-v2/services/common/admin-service/main.py
+++ b/api-v2/services/common/admin-service/main.py
@@ -1,11 +1,18 @@
-import os
+import os, sys
+from pathlib import Path
 from typing import List, Optional
 from fastapi import FastAPI, HTTPException, Depends
 from pydantic import BaseModel
 from motor.motor_asyncio import AsyncIOMotorClient
 from dotenv import load_dotenv
 
-from common.common.rbac import require_roles
+# Garante que os módulos compartilhados sejam encontrados sem PYTHONPATH manual.
+BASE_DIR = Path(__file__).resolve().parent
+COMMON_DIR = BASE_DIR.parent / "common"
+if str(COMMON_DIR) not in sys.path:
+    sys.path.insert(0, str(COMMON_DIR))
+
+from common.rbac import require_roles
 
 load_dotenv()
 

--- a/api-v2/services/common/matching-service/main.py
+++ b/api-v2/services/common/matching-service/main.py
@@ -1,9 +1,16 @@
-import os, asyncio, math
+import os, asyncio, math, sys
+from pathlib import Path
 from typing import Optional
 from fastapi import FastAPI
 from motor.motor_asyncio import AsyncIOMotorClient
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
 from dotenv import load_dotenv
+
+# Permite executar o serviço sem precisar exportar PYTHONPATH manualmente.
+BASE_DIR = Path(__file__).resolve().parent
+COMMON_DIR = BASE_DIR.parent / "common"
+if str(COMMON_DIR) not in sys.path:
+    sys.path.insert(0, str(COMMON_DIR))
 
 from common.kafka import make_consumer, make_producer
 from common.events import TOPIC_REQ_LIFECYCLE, EV_REQUEST_OFFERED

--- a/frontend/utils/config.ts
+++ b/frontend/utils/config.ts
@@ -82,11 +82,17 @@ const resolveExpoHost = () => {
 
 const expoHost = resolveExpoHost();
 const DEV_PROTOCOL = process.env.EXPO_PUBLIC_DEV_PROTOCOL || 'http';
-const DEV_API_PORT = process.env.EXPO_PUBLIC_API_PORT || '8001';
+const DEFAULT_GATEWAY_PORT = process.env.EXPO_PUBLIC_GATEWAY_PORT || '8015';
+const DEV_API_PORT = process.env.EXPO_PUBLIC_API_PORT || DEFAULT_GATEWAY_PORT;
 const DEV_SOCKET_PORT = process.env.EXPO_PUBLIC_SOCKET_PORT || DEV_API_PORT;
 
-const fallbackApiHost = expoHost ? `${DEV_PROTOCOL}://${expoHost}:${DEV_API_PORT}` : '';
-const fallbackSocketHost = expoHost ? `${DEV_PROTOCOL}://${expoHost}:${DEV_SOCKET_PORT}` : '';
+const fallbackHost = expoHost || (Platform.OS === 'android' ? '10.0.2.2' : 'localhost');
+const fallbackApiHost = fallbackHost
+  ? `${DEV_PROTOCOL}://${fallbackHost}:${DEV_API_PORT}`
+  : '';
+const fallbackSocketHost = fallbackHost
+  ? `${DEV_PROTOCOL}://${fallbackHost}:${DEV_SOCKET_PORT}`
+  : '';
 
 const resolveServiceUrl = (explicit?: string, fallbackBase?: string, fallbackPath?: string) => {
   const trimmedExplicit = stripTrailingSlash(explicit);
@@ -112,7 +118,7 @@ export const API_URL =
   rawApiUrl ||
   rawApiGatewayUrl ||
   fallbackApiHost ||
-  'https://eedfd16e8f89.ngrok-free.app';
+  `${DEV_PROTOCOL}://localhost:${DEV_API_PORT}`;
 export const API_BASE_URL = rawApiBaseUrl || ensurePath(API_URL, '/api');
 
 // Endpoints específicos


### PR DESCRIPTION
## Summary
- ensure matching-service and admin-service automatically discover the shared common package so they boot without manual PYTHONPATH tweaks
- fix the admin-service RBAC import to use the correct common module path
- update the mobile config defaults to point at the API gateway (port 8015) when no explicit URLs are provided

## Testing
- python -m compileall api-v2/services/common/matching-service/main.py api-v2/services/common/admin-service/main.py
- npx tsc --noEmit *(fails: pre-existing type definitions for Expo/Stripe/Supabase and optional cleanup callbacks)*

------
https://chatgpt.com/codex/tasks/task_e_68ca39cec2648328ba079b937cf8f2a1