### PR TITLE
Fix service import paths and harden Kafka bootstrap

### DIFF
--- a/api-v2/services/common/admin-service/main.py
+++ b/api-v2/services/common/admin-service/main.py
@@ -1,11 +1,18 @@
-import os
+import os, sys
+from pathlib import Path
 from typing import List, Optional
 from fastapi import FastAPI, HTTPException, Depends
 from pydantic import BaseModel
 from motor.motor_asyncio import AsyncIOMotorClient
 from dotenv import load_dotenv
 
-from common.common.rbac import require_roles
+# Garante que os módulos compartilhados sejam encontrados sem PYTHONPATH manual.
+BASE_DIR = Path(__file__).resolve().parent
+SERVICE_ROOT = BASE_DIR.parent
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+from common.rbac import require_roles
 
 load_dotenv()
 

--- a/api-v2/services/common/matching-service/main.py
+++ b/api-v2/services/common/matching-service/main.py
@@ -1,11 +1,18 @@
-import os, asyncio, math
+import os, asyncio, math, sys
+from pathlib import Path
 from typing import Optional
 from fastapi import FastAPI
 from motor.motor_asyncio import AsyncIOMotorClient
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
 from dotenv import load_dotenv
 
-from common.kafka import make_consumer, make_producer
+# Permite executar o serviço sem precisar exportar PYTHONPATH manualmente.
+BASE_DIR = Path(__file__).resolve().parent
+SERVICE_ROOT = BASE_DIR.parent
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+from common.kafka import make_consumer_with_retry, make_producer
 from common.events import TOPIC_REQ_LIFECYCLE, EV_REQUEST_OFFERED
 
 load_dotenv()
@@ -80,8 +87,10 @@ async def consume():
 @app.on_event("startup")
 async def start():
     global consumer, producer
-    consumer = make_consumer(REQ_TOPIC, group_id="matching-service")
-    await consumer.start()
+    consumer = await make_consumer_with_retry(
+        REQ_TOPIC,
+        group_id="matching-service",
+    )
     producer = await make_producer()
     asyncio.create_task(consume())
 

--- a/api-v2/services/common/payment-service/main.py
+++ b/api-v2/services/common/payment-service/main.py
@@ -1,10 +1,17 @@
-import os
+import os, sys
 from fastapi import FastAPI, HTTPException, Header, Request
 from pydantic import BaseModel
 from dotenv import load_dotenv
 import stripe
 from typing import Optional
 from aiokafka import AIOKafkaProducer
+from pathlib import Path
+
+# Permite acessar o pacote compartilhado "common" ao rodar localmente ou no container.
+BASE_DIR = Path(__file__).resolve().parent
+SERVICE_ROOT = BASE_DIR.parent
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
 
 from common.events import TOPIC_REQ_LIFECYCLE
 from common.kafka import make_producer

--- a/frontend/utils/config.ts
+++ b/frontend/utils/config.ts
@@ -82,11 +82,17 @@ const resolveExpoHost = () => {
 
 const expoHost = resolveExpoHost();
 const DEV_PROTOCOL = process.env.EXPO_PUBLIC_DEV_PROTOCOL || 'http';
-const DEV_API_PORT = process.env.EXPO_PUBLIC_API_PORT || '8001';
+const DEFAULT_GATEWAY_PORT = process.env.EXPO_PUBLIC_GATEWAY_PORT || '8015';
+const DEV_API_PORT = process.env.EXPO_PUBLIC_API_PORT || DEFAULT_GATEWAY_PORT;
 const DEV_SOCKET_PORT = process.env.EXPO_PUBLIC_SOCKET_PORT || DEV_API_PORT;
 
-const fallbackApiHost = expoHost ? `${DEV_PROTOCOL}://${expoHost}:${DEV_API_PORT}` : '';
-const fallbackSocketHost = expoHost ? `${DEV_PROTOCOL}://${expoHost}:${DEV_SOCKET_PORT}` : '';
+const fallbackHost = expoHost || (Platform.OS === 'android' ? '10.0.2.2' : 'localhost');
+const fallbackApiHost = fallbackHost
+  ? `${DEV_PROTOCOL}://${fallbackHost}:${DEV_API_PORT}`
+  : '';
+const fallbackSocketHost = fallbackHost
+  ? `${DEV_PROTOCOL}://${fallbackHost}:${DEV_SOCKET_PORT}`
+  : '';
 
 const resolveServiceUrl = (explicit?: string, fallbackBase?: string, fallbackPath?: string) => {
   const trimmedExplicit = stripTrailingSlash(explicit);
@@ -112,7 +118,7 @@ export const API_URL =
   rawApiUrl ||
   rawApiGatewayUrl ||
   fallbackApiHost ||
-  'https://eedfd16e8f89.ngrok-free.app';
+  `${DEV_PROTOCOL}://localhost:${DEV_API_PORT}`;
 export const API_BASE_URL = rawApiBaseUrl || ensurePath(API_URL, '/api');
 
 // Endpoints específicos


### PR DESCRIPTION
## Summary
- ensure admin-service, payment-service and matching-service automatically include the shared /app code on sys.path
- expose a Kafka consumer helper with retry/backoff and reuse it from matching-service and socket-gateway startup

## Testing
- python -m compileall api-v2/services/common/common/kafka.py api-v2/services/common/admin-service/main.py api-v2/services/common/matching-service/main.py api-v2/services/common/payment-service/main.py api-v2/services/common/socket-gateway/main.py

------
https://chatgpt.com/codex/tasks/task_e_68ca39cec2648328ba079b937cf8f2a1